### PR TITLE
change of how process-specific events are handled

### DIFF
--- a/process
+++ b/process
@@ -23,6 +23,20 @@ local function tablify(baseTable, keyTable)
 	end
 end
 
+local directedEvents = {}
+
+function getNextDirectedEvent()
+	local proc,event
+	if #directedEvents>0 then
+		proc,event=unpack(table.remove(directedEvents,1))
+	end
+	return proc,event
+end
+
+function directedEventsWaiting()
+	return #directedEvents>0
+end
+
 local function changeHookActual(hookMask, val, add)
 	local ref, key = tablify(process.eventHooks, hookMask)
 	if add then
@@ -138,7 +152,7 @@ local Process = {
 		process.activeProcess = active
 
 		self.redirect = term.current()
-		
+
 		term.redirect(_old)
 
 		--handle filters being sent back in passback.
@@ -180,7 +194,8 @@ local Process = {
 		return true
 	end,
 	queue = function(self, ...)
-		table.insert(self.eventQueue, {...})
+		--table.insert(self.eventQueue, {...})
+		table.insert(directedEvents,{self,{...}})
 		return true
 	end,
 	kill = function(self)
@@ -289,7 +304,6 @@ function new(func, path, win, redirect)
 		thread = coroutine.create(func),
 		path = path,
 		name = fs.getName(path),
-		eventQueue = {},
 		windows = {},
 	}
 
@@ -305,7 +319,7 @@ function new(func, path, win, redirect)
 	else
 		proc.redirect = process.nullRedirect
 	end
-	
+
 	setmetatable(proc, pmeta)
 
 	proc:resume({})

--- a/procman
+++ b/procman
@@ -149,17 +149,14 @@ end
 windowCompositor:draw()
 
 while true do
-	--process individually-queued events.
-	for pID, proc in pairs(process.list) do
-		if proc then
-			proc:check()
-			if #proc.eventQueue >= 1 then
-				repeat
-					proc:resume(table.remove(proc.eventQueue, 1))
-				until #proc.eventQueue == 0
-			end
+	--process directed events, queued for specific processes
+	while process.directedEventsWaiting() do
+		local proc,event=process.getNextDirectedEvent()
+		if proc:check() then
+			proc:resume(event)
 		end
 	end
+
 	--build title bar items if a desktop is present.
 	if process.eventHooks.redraw then
 		local procs = {findHook({"redraw"})}


### PR DESCRIPTION
my lengthy description from the actual commit:

directed events, those sent to a specific process with proc:queue(), were not being handled very robustly; events sent by proc:queue while handling other events sent the same way could easily be missed, which meant they had to wait until a after procman's following yield returned with a new system event before being processed. So, replacing individual queues per-process with a single queue in the process api of {process,
event} pairs.

This has the side-effect of preserving the true order of events overall, rather than having the order be consistent only per-processs.

The code changes in procman also eliminate an edge case where the order of processes in process.list might change during the handling of directed events while iterating over it, which could cause processes to be visited repeatedly or skipped entirely.